### PR TITLE
Enable capability to handle tests that may cause a panic

### DIFF
--- a/test/produce_test.go
+++ b/test/produce_test.go
@@ -5,6 +5,17 @@ import (
 	"testing"
 )
 
+/*
+func panicFunc(){
+	panic("panic test")
+}
+
+func TestPanic(t *testing.T) {
+	panicFunc()
+}
+
+*/
+
 func TestPass1(t *testing.T) {
 	// pass
 }


### PR DESCRIPTION
If a test cause a panic, the json output from go test does not show "Action: fail". In order to handle this, create a visit map, and check if the test is runned but not record as fail, skip, and pass. If such test exist, record it as failing test.